### PR TITLE
Feat/v2.0.0 release prep

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - New CLI scaffold with `run`, `check`, and `version` commands.
 - New CLI `smoke` command for lightweight environment/input validation and report output.
 - New CLI `smoke-report` command to summarize and evaluate `smoke_report.txt` files.
+- New legacy setup reference doc: `docs/legacy/thesis_environment_setup.md`.
 - Legacy config compatibility loader for `repbox_config.txt`.
 - Initial adapter and workflow engine stubs for phased migration.
 - Shared adapter command runner (`run_command`) with timeout and structured results.
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `repbox smoke` now writes `schema_version=1`, and `repbox smoke-report` validates schema compatibility.
 - Version metadata now targets `2.0.0-dev` / `2.0.0.dev0` for release preparation.
 - README versioning and command coverage notes now reflect current scaffold state.
+- README was overhauled for modern onboarding, CLI usage, and research roadmap clarity.
 
 ### Planned
 - Environment and dependency setup improvements.

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `repbox run` and `repbox smoke` now emit actionable tool diagnostics (failing tool names, paths, and hints).
 - `repbox smoke-report` now supports `--json` output for machine-readable summaries.
 - `repbox smoke` now writes `schema_version=1`, and `repbox smoke-report` validates schema compatibility.
+- Version metadata now targets `2.0.0-dev` / `2.0.0.dev0` for release preparation.
+- README versioning and command coverage notes now reflect current scaffold state.
 
 ### Planned
 - Environment and dependency setup improvements.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Notes:
 - Changelog: `Changelog.md`
 - Release workflow: `docs/process/releasing.md`
 - Release notes templates: `docs/process/release_notes_templates.md`
-- v0.3.0 implementation spec: `IMPLEMENTATION_SPEC_V0.3.0.md`
+- Legacy v0.3.0 implementation spec: `IMPLEMENTATION_SPEC_V0.3.0.md`
 - GitHub Projects playbook: `docs/process/github_project_playbook.md`
 
 ## Versioning model
 - Semantic Versioning (`MAJOR.MINOR.PATCH`).
-- `0.x.y` is used while architecture and interfaces are still stabilizing.
-- `1.0.0` will be cut when CLI behavior and configuration schema are declared stable.
+- `v2.0.0` is the current release-preparation target for the modernized Python CLI scaffold.
+- Ongoing branch work continues through small, reviewable feature slices merged into `master`.
 
 ## Development workflow
 1. Create a focused branch per task (`feat/*`, `fix/*`, `docs/*`, `test/*`).
@@ -37,9 +37,9 @@ Notes:
 3. Update `Changelog.md` (`Unreleased`) for user-visible changes.
 4. Merge only when local validation and docs updates are complete.
 
-## v0.3.0 Milestone A scaffold
+## Current scaffold status
 - New package scaffold under `src/repbox/`.
-- New Python CLI scaffold with commands: `run`, `check`, `version`.
+- New Python CLI scaffold with commands: `run`, `check`, `smoke`, `smoke-report`, `version`.
 - Legacy tool-path compatibility loader for `repbox_config.txt`.
 - Initial adapter and workflow-engine stubs for phased migration.
 

--- a/README.md
+++ b/README.md
@@ -1,229 +1,64 @@
 # RepBox
 
-RepBox is a transposable element discovery and annotation workflow created during PhD thesis research.
+RepBox is a transposable element discovery and annotation workflow originally created during PhD thesis research and now actively modernized as a Python-first CLI platform.
 
-## Overview
-- Legacy thesis-era pipeline with active modernization in progress.
-- Current modernization track: Python-first architecture and modular adapters.
-- Development planning is managed in GitHub Projects (Kanban workflow).
+## Current status
+- Modernized CLI scaffold is active under `src/repbox/`.
+- Current commands: `run`, `check`, `smoke`, `smoke-report`, `version`.
+- Adapter-based integration is in place for RepeatModeler/RepeatMasker paths.
+- Release target is `v2.0.0` as a stable platform baseline.
 
-## Quick start (development scaffold)
+## Quick start
+
 From repository root:
 
-1. `python -m pip install -e .`
-2. `python -m repbox version`
-3. `python -m repbox check --legacy-config repbox_config.txt`
-4. `python -m repbox run --input <genome.fa> --out <output_dir> --threads 4`
+```bash
+python -m pip install -e .
+python -m repbox version
+python -m repbox check --legacy-config repbox_config.txt
+python -m repbox smoke --input <genome.fa> --out <output_dir>
+python -m repbox smoke-report --report <output_dir>/smoke_report.txt --json
+```
 
 Notes:
-- `repbox check` returning non-zero is expected if legacy tool paths are missing on your machine.
-- The new CLI currently provides Milestone A scaffold behavior while migration continues.
+- `check` and `smoke` can return non-zero when legacy external tool paths are missing.
+- `smoke-report` supports human-readable and `--json` machine-readable output.
 
-## Project documentation map
+## CLI commands
+
+- `repbox version`: print package version.
+- `repbox check --legacy-config <path>`: validate configured external tools.
+- `repbox run --input <fa> --out <dir> [--threads N] [--engine ncbi]`: run scaffolded pipeline path.
+- `repbox smoke --input <fa> --out <dir>`: write `smoke_report.txt` with tool diagnostics.
+- `repbox smoke-report --report <path> [--json]`: summarize or parse smoke reports.
+
+## Versioning and release model
+
+- RepBox uses Semantic Versioning (`MAJOR.MINOR.PATCH`).
+- `v2.0.0` is the baseline milestone for the modernized CLI contract and release workflow.
+- Ongoing work continues as small PR slices merged to `master`.
+
+## Development workflow
+
+1. Create a focused branch (`feat/*`, `fix/*`, `docs/*`, `test/*`).
+2. Make scoped changes and run local validation.
+3. Update `Changelog.md` (`Unreleased`) for user-visible changes.
+4. Open PR to `master`, merge when checks pass.
+
+## Documentation map
+
 - Changelog: `Changelog.md`
 - Release workflow: `docs/process/releasing.md`
 - Release notes templates: `docs/process/release_notes_templates.md`
-- Legacy v0.3.0 implementation spec: `IMPLEMENTATION_SPEC_V0.3.0.md`
-- GitHub Projects playbook: `docs/process/github_project_playbook.md`
+- GitHub project playbook: `docs/process/github_project_playbook.md`
+- Legacy implementation spec: `IMPLEMENTATION_SPEC_V0.3.0.md`
+- Legacy thesis environment setup: `docs/legacy/thesis_environment_setup.md`
 
-## Versioning model
-- Semantic Versioning (`MAJOR.MINOR.PATCH`).
-- `v2.0.0` is the current release-preparation target for the modernized Python CLI scaffold.
-- Ongoing branch work continues through small, reviewable feature slices merged into `master`.
+## Research roadmap
 
-## Development workflow
-1. Create a focused branch per task (`feat/*`, `fix/*`, `docs/*`, `test/*`).
-2. Open a pull request into `master`.
-3. Update `Changelog.md` (`Unreleased`) for user-visible changes.
-4. Merge only when local validation and docs updates are complete.
+`v2.0.0` marks software baseline stabilization. Paper-oriented milestones can build on top:
 
-## Current scaffold status
-- New package scaffold under `src/repbox/`.
-- New Python CLI scaffold with commands: `run`, `check`, `smoke`, `smoke-report`, `version`.
-- Legacy tool-path compatibility loader for `repbox_config.txt`.
-- Initial adapter and workflow-engine stubs for phased migration.
-
-## Legacy dependency installation reference
-The remaining sections below document the original dependency setup used for the thesis-era pipeline.
-They are preserved for reproducibility and migration support.
-
-# Create Home directory for repbox
-```
-mkdir $HOME/repbox/bin
-repbox=$HOME/repbox/bin
-cd $repbox
-```
-
-
-
-# Included Dependencies
-### HelitronScanner
-```
-# Version included, download is not needed.
-```
-
-### SINE_Scan
-```
-# Modified version is included and downloading is not necessary; simple run the setup bash script located in the SINE_Scan directory.
-```
-
-
-
-
-
-
-# Installing Dependencies
-## Tandem Repeat Finder (source)
-```
-wget https://github.com/Benson-Genomics-Lab/TRF/archive/refs/tags/v4.09.1.tar.gz
-tar xzvf v4.*
-cd TRF-4*
-mkdir build
-cd build
-../configure
-make
-sudo make install
-cd $repbox
-```
-
-
-## RepeatScout (source)
-```
-wget http://www.repeatmasker.org/RepeatScout-1.0.6.tar.gz
-tar xzvf RepeatScout-1.0.6.tar.gz
-cd RepeatScout-1.0.6
-make
-cd $repbox
-```
-
-
-## RMBLAST (pre-compiled)
-```
-wget http://www.repeatmasker.org/rmblast/rmblast-2.14.0+-x64-macosx.tar.gz
-tar xzvf rmblast-2.14.0+-x64-macosx.tar.gz
-cd $repbox
-```
-
-
-## LTR_retriever (pre-compiled)
-```
-wget -qO- https://github.com/oushujun/LTR_retriever/archive/refs/tags/v2.9.0.tar.gz > ltr_retriever_v2.9.0.tar.gz
-tar xzvf ltr_retriever_v2.9.0.tar.gz
-cd $repbox
-```
-
-
-## MAFFT (source)
-```
-wget --no-check-certificate https://mafft.cbrc.jp/alignment/software/mafft-7.490-with-extensions-src.tgz
-tar xvf mafft-7.490-with-extensions-src.tgz
-cd mafft-7.490-with-extensions/core
-sed '1s@^PREFIX = /usr/local$@PREFIX = ~/repbox/mafft-7.490-with-extensions@' Makefile > temp && mv temp Makefile
-make clean
-make
-make install
-cd ..
-cd extensions
-sed '1s@^PREFIX = /usr/local$@PREFIX = ~/repbox/mafft-7.490-with-extensions@' Makefile > temp && mv temp Makefile
-make clean
-make
-make install
-cd $repbox
-```
-
-
-## CD-HIT (source)
-```
-wget https://github.com/weizhongli/cdhit/releases/download/V4.8.1/cd-hit-v4.8.1-2019-0228.tar.gz
-tar xvf cd-hit-v4.8.1-2019-0228.tar.gz
-cd cd-hit-v4.8.1-2019-0228
-sudo make openmp=no
-sudo make install
-cd $repbox
-```
-
-## NINJA (Homebrew & source)
-```
-wget https://wheelerlab.org/software/ninja/files/ninja.tgz
-tar xvf ninja.tgz
-```
-
-## MITEFinderII
-```
-git clone https://github.com/jhu99/miteFinder.git
-cd miteFinder
-make
-cd $repbox
-```
-
-## VSEARCH
-Development environment for repbox was Intel macOS and install instructions for VSEARCH are consistent with this architecture. Please refer to the [VSEARCH GitHub]('https://github.com/torognes/vsearch’) for instructions specific to your system.
-```
-wget https://github.com/torognes/vsearch/releases/download/v2.22.1/vsearch-2.22.1-macos-x86_64.tar.gz
-tar xzf vsearch-2.22.1-macos-x86_64.tar.gz
-cd vsearch-2.22.1-macos-x86_64
-```
-
-
-## Local Homebrew Formulas - https://github.com/Ensembl/homebrew-external/tree/master
-```
-# MUSCLE 
-brew install local_homebrew_formulas/muscle.rb
-
-# EMBOSS
-brew install local_homebrew_formulas/emboss.rb
-
-# Bedtools
-brew install local_homebrew_formulas/bedtools.rb
-
-# BLAST
-brew install local_homebrew_formulas/blast.rb
-
-#GenomeTools (LTRHarvest)
-brew install local_homebrew_formulas/genometools.rb
-
-#RECON
-brew install local_homebrew_formulas/recon.rb
-
-#dos2unix
-brew install local_homebrew_formulas/dos2unix.rb
-
-```
-
-## RepeatModeler 2.0.1
-```
-cd $HOME/repbox/bin
-wget https://github.com/Dfam-consortium/RepeatModeler/archive/refs/tags/2.0.1.tar.gz
-tar -zxvf 2.0.1.tar.gz
-cd RepeatModeler-2.0.1/
-```
-
-## RepeatMasker 4.1.3.p1
-```
-cd $HOME/repbox/bin
-wget https://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.3-p1.tar.gz
-tar xvf RepeatMasker-4.1.3-p1.tar.gz
-head -25 RepeatMasker/Libraries/Dfam.h5 # Check for release 3.6
-```
-
-### Repbase
-- Updated versions are behind a paywall. Most-recent open-access version included is RepBaseRepeatMaskerEdition-20181026.tar.gz
-```
-cd $HOME/repbox/bin
-cp RepBaseRepeatMaskerEdition-20181026.tar.gz RepeatMasker
-cd RepeatMasker
-tar xvf RepBaseRepeatMaskerEdition-20181026.tar.gz
-```
-
-
-# RepeatModeler & RepeatMasker Configuration
-```
-### RepeatModeler
-cd $HOME/repbox/bin
-perl ./RepeatModeler-2.0.1/configure
-
-cd $HOME/repbox/bin
-### RepeatMasker
-perl ./RepeatMasker/configure
-
-```
+- `v2.1`: reproducibility benchmarks and baseline comparisons.
+- `v2.2`: broader biological validation datasets and analysis.
+- `v2.3`: manuscript-aligned figures, tables, and methods narrative.
+- `v2.4`: submission-ready reproducibility package.

--- a/docs/legacy/thesis_environment_setup.md
+++ b/docs/legacy/thesis_environment_setup.md
@@ -1,0 +1,195 @@
+# Legacy Thesis Environment Setup
+
+This document preserves the original dependency installation steps used for the thesis-era RepBox pipeline.
+
+These instructions are retained for reproducibility and migration reference.
+
+## Create home directory for RepBox
+
+```bash
+mkdir "$HOME/repbox/bin"
+repbox="$HOME/repbox/bin"
+cd "$repbox"
+```
+
+## Included dependencies
+
+### HelitronScanner
+
+```bash
+# Version included, download is not needed.
+```
+
+### SINE_Scan
+
+```bash
+# Modified version is included; run the setup script in the SINE_Scan directory.
+```
+
+## Installing dependencies
+
+### Tandem Repeat Finder (source)
+
+```bash
+wget https://github.com/Benson-Genomics-Lab/TRF/archive/refs/tags/v4.09.1.tar.gz
+tar xzvf v4.*
+cd TRF-4*
+mkdir build
+cd build
+../configure
+make
+sudo make install
+cd "$repbox"
+```
+
+### RepeatScout (source)
+
+```bash
+wget http://www.repeatmasker.org/RepeatScout-1.0.6.tar.gz
+tar xzvf RepeatScout-1.0.6.tar.gz
+cd RepeatScout-1.0.6
+make
+cd "$repbox"
+```
+
+### RMBLAST (pre-compiled)
+
+```bash
+wget http://www.repeatmasker.org/rmblast/rmblast-2.14.0+-x64-macosx.tar.gz
+tar xzvf rmblast-2.14.0+-x64-macosx.tar.gz
+cd "$repbox"
+```
+
+### LTR_retriever (pre-compiled)
+
+```bash
+wget -qO- https://github.com/oushujun/LTR_retriever/archive/refs/tags/v2.9.0.tar.gz > ltr_retriever_v2.9.0.tar.gz
+tar xzvf ltr_retriever_v2.9.0.tar.gz
+cd "$repbox"
+```
+
+### MAFFT (source)
+
+```bash
+wget --no-check-certificate https://mafft.cbrc.jp/alignment/software/mafft-7.490-with-extensions-src.tgz
+tar xvf mafft-7.490-with-extensions-src.tgz
+cd mafft-7.490-with-extensions/core
+sed '1s@^PREFIX = /usr/local$@PREFIX = ~/repbox/mafft-7.490-with-extensions@' Makefile > temp && mv temp Makefile
+make clean
+make
+make install
+cd ..
+cd extensions
+sed '1s@^PREFIX = /usr/local$@PREFIX = ~/repbox/mafft-7.490-with-extensions@' Makefile > temp && mv temp Makefile
+make clean
+make
+make install
+cd "$repbox"
+```
+
+### CD-HIT (source)
+
+```bash
+wget https://github.com/weizhongli/cdhit/releases/download/V4.8.1/cd-hit-v4.8.1-2019-0228.tar.gz
+tar xvf cd-hit-v4.8.1-2019-0228.tar.gz
+cd cd-hit-v4.8.1-2019-0228
+sudo make openmp=no
+sudo make install
+cd "$repbox"
+```
+
+### NINJA (source)
+
+```bash
+wget https://wheelerlab.org/software/ninja/files/ninja.tgz
+tar xvf ninja.tgz
+```
+
+### MITEFinderII
+
+```bash
+git clone https://github.com/jhu99/miteFinder.git
+cd miteFinder
+make
+cd "$repbox"
+```
+
+### VSEARCH
+
+The original development environment was Intel macOS. For platform-specific updates, see the VSEARCH repository:
+https://github.com/torognes/vsearch
+
+```bash
+wget https://github.com/torognes/vsearch/releases/download/v2.22.1/vsearch-2.22.1-macos-x86_64.tar.gz
+tar xzf vsearch-2.22.1-macos-x86_64.tar.gz
+cd vsearch-2.22.1-macos-x86_64
+```
+
+### Local Homebrew formulas
+
+Reference:
+https://github.com/Ensembl/homebrew-external/tree/master
+
+```bash
+# MUSCLE
+brew install local_homebrew_formulas/muscle.rb
+
+# EMBOSS
+brew install local_homebrew_formulas/emboss.rb
+
+# Bedtools
+brew install local_homebrew_formulas/bedtools.rb
+
+# BLAST
+brew install local_homebrew_formulas/blast.rb
+
+# GenomeTools (LTRHarvest)
+brew install local_homebrew_formulas/genometools.rb
+
+# RECON
+brew install local_homebrew_formulas/recon.rb
+
+# dos2unix
+brew install local_homebrew_formulas/dos2unix.rb
+```
+
+### RepeatModeler 2.0.1
+
+```bash
+cd "$HOME/repbox/bin"
+wget https://github.com/Dfam-consortium/RepeatModeler/archive/refs/tags/2.0.1.tar.gz
+tar -zxvf 2.0.1.tar.gz
+cd RepeatModeler-2.0.1/
+```
+
+### RepeatMasker 4.1.3.p1
+
+```bash
+cd "$HOME/repbox/bin"
+wget https://www.repeatmasker.org/RepeatMasker/RepeatMasker-4.1.3-p1.tar.gz
+tar xvf RepeatMasker-4.1.3-p1.tar.gz
+head -25 RepeatMasker/Libraries/Dfam.h5 # Check for release 3.6
+```
+
+### Repbase
+
+Updated versions are behind a paywall. The latest open-access version used here is `RepBaseRepeatMaskerEdition-20181026.tar.gz`.
+
+```bash
+cd "$HOME/repbox/bin"
+cp RepBaseRepeatMaskerEdition-20181026.tar.gz RepeatMasker
+cd RepeatMasker
+tar xvf RepBaseRepeatMaskerEdition-20181026.tar.gz
+```
+
+## RepeatModeler & RepeatMasker configuration
+
+```bash
+# RepeatModeler
+cd "$HOME/repbox/bin"
+perl ./RepeatModeler-2.0.1/configure
+
+# RepeatMasker
+cd "$HOME/repbox/bin"
+perl ./RepeatMasker/configure
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repbox"
-version = "0.3.0.dev0"
+version = "2.0.0.dev0"
 description = "RepBox Python-first pipeline scaffold"
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/repbox/__init__.py
+++ b/src/repbox/__init__.py
@@ -1,4 +1,4 @@
-"""RepBox Python package scaffold for v0.3.0."""
+"""RepBox Python package scaffold for v2.0.0 release preparation."""
 
 __all__ = ["__version__"]
-__version__ = "0.3.0-dev"
+__version__ = "2.0.0-dev"


### PR DESCRIPTION
## Summary
- Overhauled `README.md` to provide clearer onboarding and current project framing.
- Added explicit sections for quickstart, CLI command usage, versioning model, development workflow, documentation map, and research roadmap.
- Moved thesis-era dependency/install instructions out of `README.md` into a dedicated legacy document:
  - `docs/legacy/thesis_environment_setup.md`
- Updated `Changelog.md` (`Unreleased`) to record README modernization and legacy-doc extraction.

## Scope
- In scope:
  - `README.md` (full restructure + modernization)
  - `docs/legacy/thesis_environment_setup.md` (new; preserved legacy setup details)
  - `Changelog.md` (`Unreleased` updates)
- Out of scope:
  - runtime/CLI behavior changes
  - adapter/workflow logic changes
  - release tagging/version-cut actions

## Validation
- [x] Local command(s) run
- [x] Docs updated (if needed)
- [x] Changelog updated (`Unreleased`)

Commands run:
```bash
[python](http://_vscodecontentref_/0) -m unittest [test_cli.py](http://_vscodecontentref_/1)
# Result: OK (16 tests)